### PR TITLE
Close the picker after selection

### DIFF
--- a/js/twemoji-picker.js
+++ b/js/twemoji-picker.js
@@ -894,6 +894,7 @@
         pickerHeight: 150,
         pickerWidth: null,
         placeholder: '',
+        closePickerAfterSelection: false,
     };
 
     $.TwemojiPicker.prototype = {
@@ -1099,6 +1100,10 @@
                 }
             } else if (document.selection && document.selection.type != 'Control') {
                 document.selection.createRange().pasteHTML(text);
+            }
+            
+            if(this.options.closePickerAfterSelection) {
+                this.closePicker();    
             }
         }
     };


### PR DESCRIPTION
The option is given to close the picker automatically after the emoji selection.
Option: closePickerAfterSelection
Default Value: false
Accepted Values: true/false